### PR TITLE
Lint with type info

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:watch": "npm run cleanup && lerna run compile:watch --stream",
     "cleanup": "lerna run cleanup --stream --parallel",
     "demo": "npm run build && (cd packages/demo-app && npm run start)",
-    "lint": "tslint --fix '**/*.ts{,x}' -e '**/**/*d.ts' -e '**/node_modules/**'",
+    "lint": "lerna run lint",
     "publish": "lerna publish --force-publish=* --skip-npm --skip-git",
     "prepublish": "npm run build"
   },
@@ -36,7 +36,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^22.0.4",
     "tslint": "^5.9.1",
-    "tslint-config-bunch-of-friends": "^1.0.1",
+    "tslint-config-bunch-of-friends": "^1.0.2",
     "tslint-eslint-rules": "^5.0.0",
     "typescript": "^2.7.2"
   }

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -4,7 +4,8 @@
     "scripts": {
         "compile": "webpack",
         "cleanup": "rimraf -rf dist coverage",
-        "start": "webpack-dev-server --watch-content-base --open"
+        "start": "webpack-dev-server --watch-content-base --open",
+        "lint": "tslint --fix '**/*.ts{,x}' -e '**/**/*d.ts' -e '**/node_modules/**' -p ."
     },
     "publishConfig": {
         "access": "public"

--- a/packages/package-a/package.json
+++ b/packages/package-a/package.json
@@ -8,7 +8,8 @@
         "test": "jest --config ../../jest.config.json --rootDir",
         "compile": "tsc",
         "compile:watch": "tsc -w",
-        "cleanup": "rimraf -rf dist coverage"
+        "cleanup": "rimraf -rf dist coverage",
+        "lint": "tslint --fix '**/*.ts{,x}' -e '**/**/*d.ts' -e '**/node_modules/**' -p ."
     },
     "publishConfig": {
         "access": "public"

--- a/packages/some-other-packages/package-b/package.json
+++ b/packages/some-other-packages/package-b/package.json
@@ -8,7 +8,8 @@
         "test": "jest --config ../../../jest.config.json --rootDir",
         "compile": "tsc",
         "compile:watch": "tsc -w",
-        "cleanup": "rimraf -rf dist coverage"
+        "cleanup": "rimraf -rf dist coverage",
+        "lint": "tslint --fix '**/*.ts{,x}' -e '**/**/*d.ts' -e '**/node_modules/**' -p ."
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Latest version of `tslint-config-bunch-of-friends` requires extra type info (need to pass a `tsconfig.json` to the lint command). Since the `tsconfig.json` is defined per package, it makes sense to use `lerna` to run the lint command, and give a local path to the `tsconfig.json` for each package.